### PR TITLE
fix: adopt @vue/composition-api and declare prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@vue/composition-api": "^1.4.3",
     "core-js": "^3.6.5",
     "vue": "^2.6.11"
   },

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -88,13 +88,18 @@
 </template>
 
 <script lang="ts">
-export default {
+import { defineComponent, PropType } from "@vue/composition-api";
+export default defineComponent({
   name: "HelloWorld",
   props: {
-    msg: String,
-    onClick: Function,
+    msg: {
+      type: String,
+    },
+    onClick: {
+      type: Function as PropType<() => void>,
+    },
   },
-};
+});
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->


### PR DESCRIPTION
This adopts the composition API and adds types needed for properties on Vue `this` to be bound properly, so that Volar can rely on accurate typings. Fixes https://github.com/johnsoncodehk/volar/issues/849#issuecomment-1008167059